### PR TITLE
Soc if possible

### DIFF
--- a/exemples/get-leaf-info.py
+++ b/exemples/get-leaf-info.py
@@ -44,6 +44,7 @@ print "time_to_full_trickle %s" % leaf_info.time_to_full_trickle
 print "time_to_full_l2 %s" % leaf_info.time_to_full_l2
 print "time_to_full_l2_6kw %s" % leaf_info.time_to_full_l2_6kw
 print "leaf_info.battery_percent %s" % leaf_info.battery_percent
+print "leaf_info.state_of_charge %s" % leaf_info.state_of_charge
 
 
 result_key = l.request_update()

--- a/pycarwings2/responses.py
+++ b/pycarwings2/responses.py
@@ -541,6 +541,14 @@ class CarwingsLatestBatteryStatusResponse(CarwingsResponse):
 
 		self.battery_percent = 100 * float(self.battery_remaining_amount) / float(self.battery_capacity)
 
+		# Leaf 2016 has SOC (State Of Charge) in BatteryStatus, a more accurate battery_percentage
+		if "SOC" in bs:
+			self.state_of_charge = bs["SOC"]["Value"]
+			# optional?
+			#self.battery_percent = self.soc
+		else:
+			self.state_of_charge = None
+
 class CarwingsElectricRateSimulationResponse(CarwingsResponse):
 	def __init__(self, status):
 		CarwingsResponse.__init__(self, status)


### PR DESCRIPTION
See also: https://github.com/jdhorne/pycarwings2/issues/13

Leaf 2016 also has SOC (state_of_charge) in it's data. This seems a more accurate battery_percentage, as it shows the exact same percentage as you seen on the dashboard

Checking IF SOC is available in records, and setting state_of_charge to None if not